### PR TITLE
patch for set-verkadaAccessUserEmploymentDetail

### DIFF
--- a/Public/Set-VerkadaAccessUserEmployementDetail.ps1
+++ b/Public/Set-VerkadaAccessUserEmployementDetail.ps1
@@ -10,7 +10,7 @@ function Set-VerkadaAccessUserEmployementDetail
 		Set-VerkadaAccessUserEmployementDetail -userId 'gjg547-uuid-of-user' -employeeId '9999sd' -department 'sales' -departmentId 'salesUS' -employeeTitle 'Account Executive' -companyName 'Contoso'
 		This will set the employment details specified in the parameters for the user specified.  The org_id and tokens will be populated from the cached created by Connect-Verkada.
 		.EXAMPLE
-		ASet-VerkadaAccessUserEmployementDetail -userId 'gjg547-uuid-of-user' -employeeId '9999sd' -department 'sales' -departmentId 'salesUS' -employeeTitle 'Account Executive' -companyName 'Contoso' -org_id 'deds343-uuid-of-org' -x_verkada_token 'sd78ds-uuid-of-verkada-token' -x_verkada_auth 'auth-token-uuid-dscsdc'
+		Set-VerkadaAccessUserEmployementDetail -userId 'gjg547-uuid-of-user' -employeeId '9999sd' -department 'sales' -departmentId 'salesUS' -employeeTitle 'Account Executive' -companyName 'Contoso' -org_id 'deds343-uuid-of-org' -x_verkada_token 'sd78ds-uuid-of-verkada-token' -x_verkada_auth 'auth-token-uuid-dscsdc'
 		This will set the employment details specified in the parameters for the user specified.  The org_id and tokens are submitted as parameters in the call.
 		.EXAMPLE
 		Import-Csv ./myUsers.csv |  Set-VerkadaAccessUserEmployementDetail

--- a/Public/Set-VerkadaAccessUserEmployementDetail.ps1
+++ b/Public/Set-VerkadaAccessUserEmployementDetail.ps1
@@ -122,6 +122,7 @@ function Set-VerkadaAccessUserEmployementDetail
 			}
 			#Write-Host -ForegroundColor Green $errorMes
 		}
+		Remove-Variable userId -ErrorAction SilentlyContinue
 	} #end process
 
 	End {


### PR DESCRIPTION
removed userID on process completion to prevent errant variable re-use error condition.