### PR TITLE
Removes redundant return from Invoke-VerkadaRestMethod

### DIFF
--- a/verkadaModule/Private/Invoke-VerkadaRestMethod.ps1
+++ b/verkadaModule/Private/Invoke-VerkadaRestMethod.ps1
@@ -127,7 +127,7 @@ function Invoke-VerkadaRestMethod
 						switch ($resCode) {
 							{($_ -eq 200) -or ($_ -eq 201)} {
 								$loop = $true
-								return $response
+								#return $response
 							}
 							429 {
 								$rt++


### PR DESCRIPTION
Removes a redundant return statement within the `Invoke-VerkadaRestMethod` function.

This avoids potential early returns and ensures consistent execution flow when handling specific response codes.